### PR TITLE
Swap images for Y-chr publications

### DIFF
--- a/_data/citations.yaml
+++ b/_data/citations.yaml
@@ -483,7 +483,7 @@
   publisher: Genes
   date: '2019-05-28'
   link: https://doi.org/gk67ng
-  image: images/thumbnails/sequencing_red_fox.png
+  image: images/thumbnails/Red_fox_ychromosome_genes10060409.png
   tags:
   - foxes
   - genomes
@@ -504,7 +504,7 @@
   publisher: Genes
   date: '2021-01-14'
   link: https://doi.org/gtj95c
-  image: images/thumbnails/Red_fox_ychromosome_genes10060409.png
+  image: images/thumbnails/sequencing_red_fox.png
   tags:
   - foxes
   - genomes

--- a/_data/sources.yaml
+++ b/_data/sources.yaml
@@ -102,13 +102,13 @@
       - disease
       - humans
 - id: doi:10.3390/genes10060409 
-  image: images/thumbnails/sequencing_red_fox.png
+  image: images/thumbnails/Red_fox_ychromosome_genes10060409.png 
   tags:
       - foxes
       - genomes
       - machine learning
 - id: doi:10.3390/genes12010097
-  image: images/thumbnails/Red_fox_ychromosome_genes10060409.png 
+  image: images/thumbnails/sequencing_red_fox.png
   tags:
       - foxes
       - genomes


### PR DESCRIPTION
Thumbnails were swapped between two y-chromosome papers

This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
