### PR TITLE
Add member affiliation filters

### DIFF
--- a/_includes/member-affiliations.html
+++ b/_includes/member-affiliations.html
@@ -1,0 +1,16 @@
+{% assign affiliations = include.affiliations | default: empty %}
+{% assign affiliations = affiliations | join: "," | split: "," | array_filter %}
+
+{% if affiliations.size > 0 %}
+  <div class="tags">
+    {% for affiliation in affiliations %}
+      <a
+        href="{{ '/team' | relative_url }}?search=&quot;{{ affiliation }}&quot;"
+        class="tag"
+        data-tooltip="Show team members with {{ affiliation }}"
+      >
+        {{ affiliation }}
+      </a>
+    {% endfor %}
+  </div>
+{% endif %}

--- a/_includes/portrait.html
+++ b/_includes/portrait.html
@@ -3,6 +3,8 @@
   | first
   | default: include
 %}
+{% assign affiliations = member.affiliations | default: empty %}
+{% assign affiliations = affiliations | join: ", " %}
 
 <div class="portrait-wrapper">
   <a
@@ -11,6 +13,7 @@
     {% endif %}
     class="portrait"
     data-style="{{ include.style }}"
+    data-search="{{ affiliations }}"
     aria-label="{{ member.name | default: "member link" }}"
   >
     <img

--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -20,6 +20,8 @@ layout: default
 
 {{ content }}
 
+{% include member-affiliations.html affiliations=page.affiliations %}
+
 {% assign related_posts = site.posts
   | where_exp: "post", "post.people contains page.slug"
 %}

--- a/_members/alina_yildirim.md
+++ b/_members/alina_yildirim.md
@@ -3,6 +3,9 @@ name: Alina Yildirim '26
 image: images/alina_yildirim.jpg
 description: Honors Thesis Student & McKinley Fellow
 role: undergrad
+affiliations:
+  - Honors Thesis Student
+  - McKinley Fellow
 ---
 
 Alina is a senior majoring in Computer Science and Statistics. She is interested in biomedical AI, especially how machine learning and language-based methods can help connect mouse and human disease. Her honors thesis focuses on comparing how experiments are described across species and what that means for translation.

--- a/_members/hildana_shiferaw.md
+++ b/_members/hildana_shiferaw.md
@@ -4,6 +4,9 @@ image: images/hildana_shiferaw.jpg
 description: Honors Thesis Student & McKinley Fellow
 role: undergrad
 group: alum
+affiliations:
+  - Honors Thesis Student
+  - McKinley Fellow
 links:
 ---
 Hildana graduate from Smith in 2025 with B.A. in Biological Sciences and a B.S. in Engineering Science. She completed the VBIL's first honors thesis, where she assessed the viability of miRNA markers for assessing ovarian cancer risk, with the goal of developing point of care diagnostic testing. After graduating from Smith, she went on to pursue a [Ph.D. in  Computational Biology and Biomedical Informatics at Yale University](https://cbb.yale.edu/students).

--- a/_members/zoe_plumridge.md
+++ b/_members/zoe_plumridge.md
@@ -3,6 +3,8 @@ name: Zo&#235; Plumridge '26
 image: images/zoe_plumridge.jpeg
 description: Honors Thesis Student
 role: undergrad
+affiliations:
+  - Honors Thesis Student
 links:
   github: zrplumridge
 ---

--- a/_scripts/search.js
+++ b/_scripts/search.js
@@ -5,7 +5,7 @@
 */
 {
   // elements to filter
-  const elementSelector = ".card, .citation, .post-excerpt";
+  const elementSelector = ".card, .citation, .post-excerpt, .portrait";
   // search box element
   const searchBoxSelector = ".search-box";
   // results info box element

--- a/team/index.md
+++ b/team/index.md
@@ -9,6 +9,33 @@ nav:
 
 Below, learn about the current and past members of the VBIL. We are always open to working with new students! Please use the contact page to reach out.
 
+{% assign affiliation_filters = site.members
+  | map: "affiliations"
+  | join: ","
+  | split: ","
+  | array_filter
+  | uniq
+  | sort
+%}
+
+{% include search-box.html %}
+
+{% if affiliation_filters.size > 0 %}
+<div class="tags">
+  {% for affiliation in affiliation_filters %}
+    <a
+      href="{{ '/team' | relative_url }}?search=&quot;{{ affiliation }}&quot;"
+      class="tag"
+      data-tooltip="Show {{ affiliation }} members"
+    >
+      {{ affiliation }}
+    </a>
+  {% endfor %}
+</div>
+{% endif %}
+
+{% include search-info.html %}
+
 {% include list.html data="members" component="portrait" filters="role: pi, group: " %}
 {% include list.html data="members" component="portrait" filters="role: postdoc, group: " %}
 {% include list.html data="members" component="portrait" filters="role: phd, group: " %}


### PR DESCRIPTION
Add a tool to filter based on research programs like SURF, AEMES, and STRIDE so that students can see ways to join.